### PR TITLE
BUG/1-second timeout before calculating (or after render) in Timer

### DIFF
--- a/src/shared/components/CountdownTimer/CountdownTimer.tsx
+++ b/src/shared/components/CountdownTimer/CountdownTimer.tsx
@@ -28,6 +28,10 @@ export const CountdownTimer = ({ launchDate }: CountdownTimerProps) => {
     return () => timerCleanup(timeoutId);
   });
 
+  useEffect(() => {
+    setTimerValues(calculateTimerValues(timeToLaunch));
+  }, []);
+
   return (
     <div className="timer-container">
       {!isLaunched ? (


### PR DESCRIPTION
[BUG: 1-second timeout before calculating (or after render) in Timer](https://trello.com/c/QYohRtA7/15-bug-1-second-timeout-before-calculating-or-after-render-in-timer)

added useEffect with calculation of timer values on  CountDownTimer component mounting