### PR TITLE
refactor/khweb-12-add props to shared buttons components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project name: _The ssspace_
 
-Link: [The ssspase](kerrimov.github.io/the-ssspace/)
+Link: [The ssspase](https://kerrimov.github.io/the-ssspace/)
 
 ## This is a web application where you can find and view news, events and astronauts of different space agencies.
 

--- a/src/components/AgenciesPage/components/components/components/AgenciesItemActions/AgenciesItemActions.tsx
+++ b/src/components/AgenciesPage/components/components/components/AgenciesItemActions/AgenciesItemActions.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { CardActions } from '@mui/material';
 import { InfoButton } from '../../../../../../shared/components/InfoButton';
+import { RoutesPath } from '../../../../../Router/routesPath';
 import './AgenciesItemActions.scss';
 
 export const AgenciesItemActions = () => (
   <CardActions className="agencies-item-actions">
-    <InfoButton />
+    <InfoButton path={RoutesPath.AGENCIES} />
   </CardActions>
 );

--- a/src/components/LaunchDetailsPage/LaunchDetailsPage.tsx
+++ b/src/components/LaunchDetailsPage/LaunchDetailsPage.tsx
@@ -19,7 +19,11 @@ export const LaunchDetailsPage = () => {
 
   return details ? (
     <Container className="launch-details-page">
-      <SecondaryButton path={RoutesPath.HOME} caption="go back" />
+      <SecondaryButton
+        caption="go back"
+        path={RoutesPath.HOME}
+        buttonSize="large"
+      />
       <Card raised className="launch-details-card">
         <CardActionArea>
           <Grid

--- a/src/components/LaunchDetailsPage/LaunchDetailsPage.tsx
+++ b/src/components/LaunchDetailsPage/LaunchDetailsPage.tsx
@@ -11,6 +11,7 @@ import { LaunchCardContent } from './components/LaunchCardContent';
 import { getActiveSlideData } from './selectors/selectors';
 import { SecondaryButton } from '../../shared/components/SecondaryButton';
 import { RoutesPath } from '../Router/routesPath';
+import { ButtonSizes } from '../../shared/components/SecondaryButton/SecondaryButton';
 import type { Launch } from '../../shared/api/types/Launch';
 import './LaunchDetailsPage.scss';
 
@@ -22,7 +23,7 @@ export const LaunchDetailsPage = () => {
       <SecondaryButton
         caption="go back"
         path={RoutesPath.HOME}
-        buttonSize="large"
+        buttonSize={ButtonSizes.LARGE}
       />
       <Card raised className="launch-details-card">
         <CardActionArea>

--- a/src/components/LaunchDetailsPage/LaunchDetailsPage.tsx
+++ b/src/components/LaunchDetailsPage/LaunchDetailsPage.tsx
@@ -11,7 +11,7 @@ import { LaunchCardContent } from './components/LaunchCardContent';
 import { getActiveSlideData } from './selectors/selectors';
 import { SecondaryButton } from '../../shared/components/SecondaryButton';
 import { RoutesPath } from '../Router/routesPath';
-import { ButtonSizes } from '../../shared/components/SecondaryButton/SecondaryButton';
+import { ButtonSizes } from '../../shared/components/SecondaryButton/types/secondaryButtonTypes';
 import type { Launch } from '../../shared/api/types/Launch';
 import './LaunchDetailsPage.scss';
 

--- a/src/shared/components/InfoButton/InfoButton.scss
+++ b/src/shared/components/InfoButton/InfoButton.scss
@@ -1,14 +1,31 @@
 @import '../../styles/variables';
 
-.agencies-item-actions-button {
-  color: $contrast-text-color;
+.list-item-actions {
+  &-button {
+    color: $contrast-text-color;
+    &:hover,
+    &:focus {
+      color: $primary-light;
+    }
 
-  &:hover,
-  &:focus {
-    color: $primary-light;
+    &-icon {
+      margin-right: 0.5rem;
+      padding-bottom: 0.2rem;
+    }
   }
 
-  &-icon {
-    margin-right: 0.5rem;
+  &-link {
+    display: flex;
+    align-items: center;
+    text-decoration: none;
+    color: $contrast-text-color;
+    &:hover,
+    &:focus {
+      color: $primary-light;
+    }
   }
+}
+
+.list-item-actions-button:hover .list-item-actions-link {
+  color: $primary-light;
 }

--- a/src/shared/components/InfoButton/InfoButton.tsx
+++ b/src/shared/components/InfoButton/InfoButton.tsx
@@ -1,5 +1,5 @@
 import React, { ReactEventHandler } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { InfoOutlined } from '@mui/icons-material';
 import { Button } from '@mui/material';
 import { RoutesPath } from '../../../components/Router/routesPath';
@@ -7,18 +7,13 @@ import './InfoButton.scss';
 
 interface InfoButtonProps {
   caption?: string;
-  path?: RoutesPath;
+  path: RoutesPath;
   clickHandler?: ReactEventHandler;
   className?: string;
 }
 
-interface LocationState {
-  pathname: string;
-}
-
 export const InfoButton = (props: InfoButtonProps) => {
   const { caption, path, clickHandler, className } = props;
-  const location: LocationState = useLocation();
 
   return (
     <Button
@@ -27,7 +22,7 @@ export const InfoButton = (props: InfoButtonProps) => {
       size="medium"
       onClick={clickHandler}
     >
-      <Link className="list-item-actions-link" to={path || location.pathname}>
+      <Link className="list-item-actions-link" to={path}>
         <InfoOutlined
           className="list-item-actions-button-icon"
           fontSize="small"

--- a/src/shared/components/InfoButton/InfoButton.tsx
+++ b/src/shared/components/InfoButton/InfoButton.tsx
@@ -1,5 +1,5 @@
 import React, { ReactEventHandler } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { InfoOutlined } from '@mui/icons-material';
 import { Button } from '@mui/material';
 import { RoutesPath } from '../../../components/Router/routesPath';
@@ -12,8 +12,14 @@ interface InfoButtonProps {
   className?: string;
 }
 
+interface LocationState {
+  pathname: string;
+}
+
 export const InfoButton = (props: InfoButtonProps) => {
   const { caption, path, clickHandler, className } = props;
+  const location: LocationState = useLocation();
+
   return (
     <Button
       className={`list-item-actions-button ${className}`}
@@ -21,16 +27,17 @@ export const InfoButton = (props: InfoButtonProps) => {
       size="medium"
       onClick={clickHandler}
     >
-      <Link
-        className="list-item-actions-link"
-        to={(path as RoutesPath) || RoutesPath.HOME}
-      >
+      <Link className="list-item-actions-link" to={path || location.pathname}>
         <InfoOutlined
           className="list-item-actions-button-icon"
           fontSize="small"
         />
-        {caption || 'info'}
+        {caption}
       </Link>
     </Button>
   );
+};
+
+InfoButton.defaultProps = {
+  caption: 'info',
 };

--- a/src/shared/components/InfoButton/InfoButton.tsx
+++ b/src/shared/components/InfoButton/InfoButton.tsx
@@ -1,18 +1,36 @@
-import React from 'react';
+import React, { ReactEventHandler } from 'react';
+import { Link } from 'react-router-dom';
 import { InfoOutlined } from '@mui/icons-material';
 import { Button } from '@mui/material';
+import { RoutesPath } from '../../../components/Router/routesPath';
 import './InfoButton.scss';
 
-export const InfoButton = () => (
-  <Button
-    className="agencies-item-actions-button"
-    variant="contained"
-    size="medium"
-  >
-    <InfoOutlined
-      className="agencies-item-actions-button-icon"
-      fontSize="small"
-    />
-    Info
-  </Button>
-);
+interface InfoButtonProps {
+  caption?: string;
+  path?: RoutesPath;
+  clickHandler?: ReactEventHandler;
+  className?: string;
+}
+
+export const InfoButton = (props: InfoButtonProps) => {
+  const { caption, path, clickHandler, className } = props;
+  return (
+    <Button
+      className={`list-item-actions-button ${className}`}
+      variant="contained"
+      size="medium"
+      onClick={clickHandler}
+    >
+      <Link
+        className="list-item-actions-link"
+        to={(path as RoutesPath) || RoutesPath.HOME}
+      >
+        <InfoOutlined
+          className="list-item-actions-button-icon"
+          fontSize="small"
+        />
+        {caption || 'info'}
+      </Link>
+    </Button>
+  );
+};

--- a/src/shared/components/InfoButton/InfoButton.tsx
+++ b/src/shared/components/InfoButton/InfoButton.tsx
@@ -12,9 +12,12 @@ interface InfoButtonProps {
   className?: string;
 }
 
-export const InfoButton = (props: InfoButtonProps) => {
-  const { caption, path, clickHandler, className } = props;
-
+export const InfoButton = ({
+  caption = 'info',
+  path,
+  clickHandler,
+  className,
+}: InfoButtonProps) => {
   return (
     <Button
       className={`list-item-actions-button ${className}`}
@@ -31,8 +34,4 @@ export const InfoButton = (props: InfoButtonProps) => {
       </Link>
     </Button>
   );
-};
-
-InfoButton.defaultProps = {
-  caption: 'info',
 };

--- a/src/shared/components/SecondaryButton/SecondaryButton.scss
+++ b/src/shared/components/SecondaryButton/SecondaryButton.scss
@@ -3,7 +3,23 @@
 .MuiButton-root.secondary-button,
 .MuiButton-root.secondary-button:hover,
 .MuiButton-root.secondary-button:focus {
-  margin: 0.5rem;
   border: $goback-button-border solid;
   font-weight: $font-weight-bold;
+}
+
+.secondary-button {
+  &-icon {
+    margin-right: 0.5rem;
+    padding-bottom: 0.2rem;
+  }
+  &-link {
+    display: flex;
+    align-items: center;
+    text-decoration: none;
+    color: $primary-dark;
+    &:hover,
+    &:focus {
+      color: $primary-main;
+    }
+  }
 }

--- a/src/shared/components/SecondaryButton/SecondaryButton.tsx
+++ b/src/shared/components/SecondaryButton/SecondaryButton.tsx
@@ -1,27 +1,39 @@
-import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import React, { ReactEventHandler } from 'react';
+import { Link } from 'react-router-dom';
 import { Button } from '@mui/material';
+import { RoutesPath } from '../../../components/Router/routesPath';
 import './SecondaryButton.scss';
 
-interface SecondaryButtonProps {
-  path: string;
-  caption: string;
+interface IconTypeProps {
+  className?: string;
+  fontSize?: 'small' | 'medium' | 'large' | 'inherit';
 }
 
-export const SecondaryButton = ({ path, caption }: SecondaryButtonProps) => {
-  const navigate = useNavigate();
-  const navigateTo = () => {
-    navigate(path);
-  };
+interface SecondaryButtonProps {
+  caption: string;
+  path?: string;
+  clickHandler?: ReactEventHandler;
+  className?: string;
+  buttonSize: 'small' | 'large' | 'medium';
+  icon?: (props: IconTypeProps) => JSX.Element;
+}
 
+export const SecondaryButton = (props: SecondaryButtonProps) => {
+  const { caption, path, clickHandler, className, buttonSize, icon } = props;
   return (
-    <Button
-      className="secondary-button"
-      size="large"
-      variant="outlined"
-      onClick={navigateTo}
-    >
-      {caption}
+    <Button className="secondary-button" size={buttonSize} variant="outlined">
+      <Link
+        className={`secondary-button-link ${className}`}
+        to={path || RoutesPath.HOME}
+        onClick={clickHandler}
+      >
+        {icon &&
+          React.createElement(icon, {
+            className: 'secondary-button-icon',
+            fontSize: 'small',
+          })}
+        {caption}
+      </Link>
     </Button>
   );
 };

--- a/src/shared/components/SecondaryButton/SecondaryButton.tsx
+++ b/src/shared/components/SecondaryButton/SecondaryButton.tsx
@@ -1,20 +1,8 @@
 import React, { ReactEventHandler } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { Button } from '@mui/material';
+import { ButtonSizes, FontSizes } from './types/secondaryButtonTypes';
 import './SecondaryButton.scss';
-
-export const enum FontSizes {
-  SMALL = 'small',
-  MEDIUM = 'medium',
-  LARGE = 'large',
-  INHERIT = 'inherit',
-}
-
-export const enum ButtonSizes {
-  SMALL = 'small',
-  MEDIUM = 'medium',
-  LARGE = 'large',
-}
 
 interface IconTypeProps {
   className?: string;
@@ -25,13 +13,9 @@ interface IconTypeProps {
     | FontSizes.INHERIT;
 }
 
-interface LocationState {
-  pathname: string;
-}
-
 interface SecondaryButtonProps {
   caption: string;
-  path?: string;
+  path: string;
   clickHandler?: ReactEventHandler;
   className?: string;
   buttonSize: ButtonSizes.SMALL | ButtonSizes.MEDIUM | ButtonSizes.LARGE;
@@ -40,20 +24,16 @@ interface SecondaryButtonProps {
 
 export const SecondaryButton = (props: SecondaryButtonProps) => {
   const { caption, path, clickHandler, className, buttonSize, Icon } = props;
-  const location: LocationState = useLocation();
 
   return (
     <Button className="secondary-button" size={buttonSize} variant="outlined">
       <Link
         className={`secondary-button-link ${className}`}
-        to={path || location.pathname}
+        to={path}
         onClick={clickHandler}
       >
         {Icon && (
-          <Icon
-            className="secondary-button-icon"
-            fontSize={FontSizes.SMALL}
-          ></Icon>
+          <Icon className="secondary-button-icon" fontSize={FontSizes.SMALL} />
         )}
         {caption}
       </Link>

--- a/src/shared/components/SecondaryButton/SecondaryButton.tsx
+++ b/src/shared/components/SecondaryButton/SecondaryButton.tsx
@@ -1,12 +1,32 @@
 import React, { ReactEventHandler } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { Button } from '@mui/material';
-import { RoutesPath } from '../../../components/Router/routesPath';
 import './SecondaryButton.scss';
+
+export const enum FontSizes {
+  SMALL = 'small',
+  MEDIUM = 'medium',
+  LARGE = 'large',
+  INHERIT = 'inherit',
+}
+
+export const enum ButtonSizes {
+  SMALL = 'small',
+  MEDIUM = 'medium',
+  LARGE = 'large',
+}
 
 interface IconTypeProps {
   className?: string;
-  fontSize?: 'small' | 'medium' | 'large' | 'inherit';
+  fontSize?:
+    | FontSizes.SMALL
+    | FontSizes.MEDIUM
+    | FontSizes.LARGE
+    | FontSizes.INHERIT;
+}
+
+interface LocationState {
+  pathname: string;
 }
 
 interface SecondaryButtonProps {
@@ -14,24 +34,27 @@ interface SecondaryButtonProps {
   path?: string;
   clickHandler?: ReactEventHandler;
   className?: string;
-  buttonSize: 'small' | 'large' | 'medium';
-  icon?: (props: IconTypeProps) => JSX.Element;
+  buttonSize: ButtonSizes.SMALL | ButtonSizes.MEDIUM | ButtonSizes.LARGE;
+  Icon?: (props: IconTypeProps) => JSX.Element;
 }
 
 export const SecondaryButton = (props: SecondaryButtonProps) => {
-  const { caption, path, clickHandler, className, buttonSize, icon } = props;
+  const { caption, path, clickHandler, className, buttonSize, Icon } = props;
+  const location: LocationState = useLocation();
+
   return (
     <Button className="secondary-button" size={buttonSize} variant="outlined">
       <Link
         className={`secondary-button-link ${className}`}
-        to={path || RoutesPath.HOME}
+        to={path || location.pathname}
         onClick={clickHandler}
       >
-        {icon &&
-          React.createElement(icon, {
-            className: 'secondary-button-icon',
-            fontSize: 'small',
-          })}
+        {Icon && (
+          <Icon
+            className="secondary-button-icon"
+            fontSize={FontSizes.SMALL}
+          ></Icon>
+        )}
         {caption}
       </Link>
     </Button>

--- a/src/shared/components/SecondaryButton/types/secondaryButtonTypes.ts
+++ b/src/shared/components/SecondaryButton/types/secondaryButtonTypes.ts
@@ -1,0 +1,12 @@
+export const enum FontSizes {
+  SMALL = 'small',
+  MEDIUM = 'medium',
+  LARGE = 'large',
+  INHERIT = 'inherit',
+}
+
+export const enum ButtonSizes {
+  SMALL = 'small',
+  MEDIUM = 'medium',
+  LARGE = 'large',
+}


### PR DESCRIPTION
[Refactor shared buttons components](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=3370&projectKey=KHWEB&view=detail&selectedIssue=KHWEB-12)

Add optional props to InfoButton component: 
 - caption: string;
 - path: enum RoutesPath value;
 - clickHandler: function ReactEventHandler; 
 - className: additional css classes, string.
 
Add props to SecondaryButton component: 
 - caption: string;
 - path: enum RoutesPath value, optional;
 - clickHandler: function ReactEventHandler, optional; 
 - className: additional css classes, string, optional;
 - buttonSize: 'small' or 'large' or  'medium';
 - icon: JSX element, optional.