### PR TITLE
bug-khweb-15/link-doesn't-navigate-to-homepage-on-notfound-page

### DIFF
--- a/src/components/NotFoundPage/NotFoundPage.tsx
+++ b/src/components/NotFoundPage/NotFoundPage.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Container, Link } from '@mui/material';
+import { Link } from 'react-router-dom';
+import { Container } from '@mui/material';
 import { RoutesPath } from '../Router/routesPath';
 import './NotFoundPage.scss';
 
@@ -8,7 +9,7 @@ export const NotFoundPage = () => (
     <h1 className="not-found-page-header">Page not found</h1>
     <p className="not-found-page-404">404</p>
     <p className="not-found-page-info">Let&apos;s use another try.</p>
-    <Link className="not-found-page-button" href={RoutesPath.HOME}>
+    <Link className="not-found-page-button" to={RoutesPath.HOME}>
       Home page
     </Link>
   </Container>


### PR DESCRIPTION
[Link doesn't navigate to homepage on notfound page](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=3370&view=detail&selectedIssue=KHWEB-15)

- changed Link component in the NotFound Page component