### PR TITLE
bug-khweb-22/events-page-returns-error-without-styles-if-api-returns-empty-list

### DIFF
--- a/src/components/EventsPage/components/EventsList/EventsList.tsx
+++ b/src/components/EventsPage/components/EventsList/EventsList.tsx
@@ -12,7 +12,7 @@ export const EventsList = () => {
   if (isLoading) return <Loader />;
 
   if (!events.length)
-    return <h2 className="event-list-empty">No events for now. Try later.</h2>;
+    return <h2 className="events-list-empty">No events for now. Try later.</h2>;
 
   return (
     <Grid container>


### PR DESCRIPTION
[Events page returns error without styles if api returns empty list](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=3370&view=detail&selectedIssue=KHWEB-22)

- fixed name in the error's className